### PR TITLE
Add support for dynamic instance ids

### DIFF
--- a/include/CommonAPI/Runtime.hpp
+++ b/include/CommonAPI/Runtime.hpp
@@ -76,6 +76,48 @@ public:
         return nullptr;
     }
 
+    template<template<typename ...> class ProxyClass_, typename ... AttributeExtensions_>
+    COMMONAPI_EXPORT std::shared_ptr<
+        ProxyClass_<AttributeExtensions_...>
+    >
+        buildDynamicProxy(const std::string &_domain,
+            const std::string &_template_instance,
+            const std::string &_instance,
+            const ConnectionId_t &_connectionId = DEFAULT_CONNECTION_ID) {
+        std::shared_ptr<Proxy> proxy
+            = createDynamicProxy(_domain,
+                ProxyClass_<AttributeExtensions_...>::getInterface(),
+                _template_instance,
+                _instance,
+                _connectionId);
+
+        if (proxy) {
+            return std::make_shared<ProxyClass_<AttributeExtensions_...>>(proxy);
+        }
+        return nullptr;
+    }
+
+    template<template<typename ...> class ProxyClass_, typename ... AttributeExtensions_>
+    COMMONAPI_EXPORT std::shared_ptr<
+        ProxyClass_<AttributeExtensions_...>
+    >
+        buildDynamicProxy(const std::string &_domain,
+            const std::string &_template_instance,
+            const std::string &_instance,
+            std::shared_ptr<MainLoopContext> _context) {
+        std::shared_ptr<Proxy> proxy
+            = createDynamicProxy(_domain,
+                ProxyClass_<AttributeExtensions_...>::getInterface(),
+                _template_instance,
+                _instance,
+                _context);
+        if (proxy) {
+            return std::make_shared<ProxyClass_<AttributeExtensions_...>>(proxy);
+        }
+        return nullptr;
+    }
+
+
     template <template<typename ...> class ProxyClass_, template<typename> class AttributeExtension_>
     COMMONAPI_EXPORT std::shared_ptr<typename DefaultAttributeProxyHelper<ProxyClass_, AttributeExtension_>::class_t>
     buildProxyWithDefaultAttributeExtension(const std::string &_domain,
@@ -124,6 +166,25 @@ public:
         return registerStub(_domain, Stub_::StubInterface::getInterface(), _instance, _service, _context);
     }
 
+    template<typename Stub_>
+    COMMONAPI_EXPORT bool registerDynamicService(const std::string &_domain,
+        const std::string &_template_instance,
+        const std::string &_instance,
+        std::shared_ptr<Stub_> _service,
+        const ConnectionId_t &_connectionId = DEFAULT_CONNECTION_ID) {
+        return registerDynamicStub(_domain, Stub_::StubInterface::getInterface(), _template_instance, _instance, _service, _connectionId);
+    }
+
+    template<typename Stub_>
+    COMMONAPI_EXPORT bool registerDynamicService(const std::string &_domain,
+        const std::string &_template_instance,
+        const std::string &_instance,
+        std::shared_ptr<Stub_> _service,
+        std::shared_ptr<MainLoopContext> _context) {
+        return registerDynamicStub(_domain, Stub_::StubInterface::getInterface(), _template_instance, _instance, _service, _context);
+    }
+
+
     COMMONAPI_EXPORT bool unregisterService(const std::string &_domain,
                             const std::string &_interface,
                             const std::string &_instance) {
@@ -147,7 +208,10 @@ private:
                                        const ConnectionId_t &);
     COMMONAPI_EXPORT std::shared_ptr<Proxy> createProxy(const std::string &, const std::string &, const std::string &,
                                        std::shared_ptr<MainLoopContext>);
-
+    COMMONAPI_EXPORT std::shared_ptr<Proxy> createDynamicProxy(const std::string &, const std::string &, const std::string &, const std::string &,
+        const ConnectionId_t &);
+    COMMONAPI_EXPORT std::shared_ptr<Proxy> createDynamicProxy(const std::string &, const std::string &, const std::string &, const std::string &,
+        std::shared_ptr<MainLoopContext>);
     COMMONAPI_EXPORT std::shared_ptr<Proxy> createProxyHelper(const std::string &, const std::string &, const std::string &,
                                              const ConnectionId_t &, bool);
     COMMONAPI_EXPORT std::shared_ptr<Proxy> createProxyHelper(const std::string &, const std::string &, const std::string &,
@@ -158,6 +222,10 @@ private:
                       std::shared_ptr<StubBase>, const ConnectionId_t &);
     COMMONAPI_EXPORT bool registerStub(const std::string &, const std::string &, const std::string &,
                       std::shared_ptr<StubBase>, std::shared_ptr<MainLoopContext>);
+    COMMONAPI_EXPORT bool registerDynamicStub(const std::string &, const std::string &, const std::string &, const std::string &,
+        std::shared_ptr<StubBase>, const ConnectionId_t &);
+    COMMONAPI_EXPORT bool registerDynamicStub(const std::string &, const std::string &, const std::string &, const std::string &,
+        std::shared_ptr<StubBase>, std::shared_ptr<MainLoopContext>);
     COMMONAPI_EXPORT bool registerStubHelper(const std::string &, const std::string &, const std::string &,
                             std::shared_ptr<StubBase>, const ConnectionId_t &, bool);
     COMMONAPI_EXPORT bool registerStubHelper(const std::string &, const std::string &, const std::string &,

--- a/src/CommonAPI/Runtime.cpp
+++ b/src/CommonAPI/Runtime.cpp
@@ -256,6 +256,20 @@ std::shared_ptr<Proxy>
 Runtime::createProxy(
         const std::string &_domain, const std::string &_interface, const std::string &_instance,
         const ConnectionId_t &_connectionId) {
+    return createDynamicProxy(_domain, _interface, _instance, _instance, _connectionId);
+}
+
+std::shared_ptr<Proxy>
+Runtime::createProxy(
+        const std::string &_domain, const std::string &_interface, const std::string &_instance,
+        std::shared_ptr<MainLoopContext> _context) {
+    return createDynamicProxy(_domain, _interface, _instance, _instance, _context);
+}
+
+std::shared_ptr<Proxy>
+Runtime::createDynamicProxy(
+    const std::string &_domain, const std::string &_interface, const std::string &_template_instance, const std::string &_instance,
+    const ConnectionId_t &_connectionId) {
     if (!isInitialized_) {
         initFactories();
     }
@@ -265,7 +279,7 @@ Runtime::createProxy(
     if (!proxy) {
         // ...it seems do not, lets try to load a library that does...
         std::lock_guard<std::mutex> itsGuard(loadMutex_);
-        std::string library = getLibrary(_domain, _interface, _instance, true);
+        std::string library = getLibrary(_domain, _interface, _template_instance, true);
         if (loadLibrary(library) || defaultFactory_) {
             proxy = createProxyHelper(_domain, _interface, _instance, _connectionId, true);
         }
@@ -274,9 +288,9 @@ Runtime::createProxy(
 }
 
 std::shared_ptr<Proxy>
-Runtime::createProxy(
-        const std::string &_domain, const std::string &_interface, const std::string &_instance,
-        std::shared_ptr<MainLoopContext> _context) {
+Runtime::createDynamicProxy(
+    const std::string &_domain, const std::string &_interface, const std::string &_template_instance, const std::string &_instance,
+    std::shared_ptr<MainLoopContext> _context) {
     if (!isInitialized_) {
         initFactories();
     }
@@ -286,7 +300,7 @@ Runtime::createProxy(
     if (!proxy) {
         // ...it seems do not, lets try to load a library that does...
         std::lock_guard<std::mutex> itsGuard(loadMutex_);
-        std::string library = getLibrary(_domain, _interface, _instance, true);
+        std::string library = getLibrary(_domain, _interface, _template_instance, true);
         if (loadLibrary(library) || defaultFactory_) {
             proxy = createProxyHelper(_domain, _interface, _instance, _context, true);
         }
@@ -298,6 +312,19 @@ Runtime::createProxy(
 bool
 Runtime::registerStub(const std::string &_domain, const std::string &_interface, const std::string &_instance,
                         std::shared_ptr<StubBase> _stub, const ConnectionId_t &_connectionId) {
+    return registerDynamicStub(_domain, _interface, _instance, _instance, _stub, _connectionId);
+}
+
+bool
+Runtime::registerStub(const std::string &_domain, const std::string &_interface, const std::string &_instance,
+                        std::shared_ptr<StubBase> _stub, std::shared_ptr<MainLoopContext> _context) {
+    return registerDynamicStub(_domain, _interface, _instance, _instance, _stub, _context);
+}
+
+
+bool
+Runtime::registerDynamicStub(const std::string &_domain, const std::string &_interface, const std::string &_template_instance, const std::string &_instance,
+    std::shared_ptr<StubBase> _stub, const ConnectionId_t &_connectionId) {
     if (!_stub) {
         return false;
     }
@@ -308,7 +335,7 @@ Runtime::registerStub(const std::string &_domain, const std::string &_interface,
 
     bool isRegistered = registerStubHelper(_domain, _interface, _instance, _stub, _connectionId, false);
     if (!isRegistered) {
-        std::string library = getLibrary(_domain, _interface, _instance, false);
+        std::string library = getLibrary(_domain, _interface, _template_instance, false);
         std::lock_guard<std::mutex> itsGuard(loadMutex_);
         if (loadLibrary(library) || defaultFactory_) {
             isRegistered = registerStubHelper(_domain, _interface, _instance, _stub, _connectionId, true);
@@ -318,8 +345,8 @@ Runtime::registerStub(const std::string &_domain, const std::string &_interface,
 }
 
 bool
-Runtime::registerStub(const std::string &_domain, const std::string &_interface, const std::string &_instance,
-                        std::shared_ptr<StubBase> _stub, std::shared_ptr<MainLoopContext> _context) {
+Runtime::registerDynamicStub(const std::string &_domain, const std::string &_interface, const std::string &_template_instance, const std::string &_instance,
+    std::shared_ptr<StubBase> _stub, std::shared_ptr<MainLoopContext> _context) {
     if (!_stub) {
         return false;
     }
@@ -330,7 +357,7 @@ Runtime::registerStub(const std::string &_domain, const std::string &_interface,
 
     bool isRegistered = registerStubHelper(_domain, _interface, _instance, _stub, _context, false);
     if (!isRegistered) {
-        std::string library = getLibrary(_domain, _interface, _instance, false);
+        std::string library = getLibrary(_domain, _interface, _template_instance, false);
         std::lock_guard<std::mutex> itsGuard(loadMutex_);
         if (loadLibrary(library) || defaultFactory_) {
             isRegistered = registerStubHelper(_domain, _interface, _instance, _stub, _context, true);


### PR DESCRIPTION
New api methods (buildDynamicProxy && registerDynamicService) are added
that allow to use a template instance which is defined in the FDEPL
file but with a different instance id.