### PR TITLE
Fix c++11 compilation

### DIFF
--- a/src/CommonAPI/Utils.cpp
+++ b/src/CommonAPI/Utils.cpp
@@ -31,7 +31,7 @@ void trim(std::string& toTrim) {
         std::find_if(
             toTrim.begin(),
             toTrim.end(),
-            std::not1(std::ptr_fun(isspace))
+            std::not1(std::function<int(int)>(isspace))
         )
     );
 
@@ -39,7 +39,7 @@ void trim(std::string& toTrim) {
         std::find_if(
             toTrim.rbegin(),
             toTrim.rend(),
-            std::not1(std::ptr_fun(isspace))).base(),
+            std::not1(std::function<int(int)>(isspace))).base(),
             toTrim.end()
     );
 }


### PR DESCRIPTION
New to this framework, just followed the "CommonAPI C D-BUS in 10 min" tutorial and ran into this compile issue.
I'm a bit surprised I'm the first one reporting this: ptr_fun is a c++03 function deprecated in c++11 and removed in c++17. 