### PR TITLE
capicxx-core-runtime 3.2.3-r7

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,38 +1,54 @@
-capi_srcs = [
-    "src/CommonAPI/**/*.cpp"
-]
-
 cc_defaults {
-    name: "capi_defaults",
+    name: "libcommonapi_defaults",
+
+    rtti: true,
+
     cppflags: [
-	"-std=c++11",
+        "-std=c++11",
         "-Wall",
         "-Wextra",
         "-Wformat",
         "-Wformat-security",
         "-Wconversion",
-	"-Wno-attributes",
+        "-Wno-attributes",
         "-fexceptions",
         "-fstrict-aliasing",
         "-fstack-protector",
         "-fasynchronous-unwind-tables",
         "-fno-omit-frame-pointer",
-        "-Werror",
-	"-fvisibility=hidden",
-	"-DCOMMONAPI_INTERNAL_COMPILATION"
-    ]
+        "-fvisibility=hidden",
+        "-Wno-ignored-attributes",
+        "-Wno-unused-private-field",
+        "-D_CRT_SECURE_NO_WARNINGS",
+        "-DCOMMONAPI_INTERNAL_COMPILATION",
+        "-DCOMMONAPI_LOGLEVEL=COMMONAPI_LOGLEVEL_VERBOSE",
+	"-DUSE_DLT",
+    ],
+
+    proprietary: true,
 }
 
 cc_library_shared {
-    name: "libCommonAPI",
-    vendor: true,
-    srcs: capi_srcs,
-    defaults: [
-        "capi_defaults"
-    ],
+    name: "libcommonapi",
+    defaults: ["libcommonapi_defaults"],
     local_include_dirs: [
-        "include"
+        "include",
     ],
-    export_include_dirs: ["include"],
-    rtti: true
+
+    shared_libs: [
+        "liblog",
+        "libutils",
+        "libboost_log",
+        "libboost_system",
+        "libboost_thread",
+    ],
+
+	export_include_dirs: [
+        "include",
+    ],
+    srcs: [
+        "src/CommonAPI/**/*.cpp"
+    ],
 }
+
+

--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,44 @@
+# Cannot convert to Android.bp as resource copying has not
+# yet implemented for soong as of 12/16/2016
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libcommonapi_dlt
+LOCAL_MODULE_TAGS := optional
+LOCAL_CLANG := true
+LOCAL_PROPRIETARY_MODULE := true
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include \
+
+LOCAL_SRC_FILES += \
+    src/CommonAPI/Address.cpp \
+    src/CommonAPI/ContainerUtils.cpp \
+    src/CommonAPI/IniFileReader.cpp \
+    src/CommonAPI/Logger.cpp \
+    src/CommonAPI/LoggerImpl.cpp \
+    src/CommonAPI/MainLoopContext.cpp \
+    src/CommonAPI/Proxy.cpp \
+    src/CommonAPI/ProxyManager.cpp \
+    src/CommonAPI/Runtime.cpp \
+    src/CommonAPI/Utils.cpp \
+
+LOCAL_C_INCLUDES := \
+	$(LOCAL_PATH)/include
+
+LOCAL_SHARED_LIBRARIES := \
+	libboost_log \
+	libboost_system \
+	libboost_thread \
+
+LOCAL_CFLAGS :=  \
+    -frtti -fexceptions \
+    -Wno-ignored-attributes \
+    -D_CRT_SECURE_NO_WARNINGS \
+    -DCOMMONAPI_INTERNAL_COMPILATION \
+    -DCOMMONAPI_LOGLEVEL=COMMONAPI_LOGLEVEL_VERBOSE \
+
+include $(BUILD_SHARED_LIBRARY)
+
+
+

--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,40 @@
 Changes
 =======
 
+v3.2.3-r7
+- Fixed warnings with gcc11 for Wextra-extra-semi flag
+- Fix capi-core-runtime Runtime::loadLibrary
+- vSomeIP Security: Update vsomeip_sec
+- Fixed commonapi-core-runtime windows build
+
+v3.2.3-r6
+- Fix race condition.
+- Remove mutex and add exception handling to RuntimeDeinit.
+- Fix double initialization of loggerImpl.
+
+v3.2.3-r5
+- Linux: avoid static initialization of std::mutex
+- Replace deprecated std::ptr_fun
+
+v3.2.3
+- Properly initialize Runtime::defaultCallTimeout_
+- Removed GENIVI copyright line
+- Fix bug in assignment operator of Variant in case of self-assignment
+- Ensure to stop struct deserialization on error
+- Implement "no_timeout" in method responses
+- Use COMMONAPI_EXPORT_CLASS_EXPLICIT to export classes
+- Removed libdlt dependency from android
+- Add support to logs in Android
+- Update android build files
+
+v3.2.2
+- Support retrieval of environment (hostname) from client identifier.
+
+v3.2.1
+- Use lock objects and remove self assignment.
+
 v3.2.0
-- Support ABI compatible changes (additional attributes, broadcast and methods added to the end of 
+- Support ABI compatible changes (additional attributes, broadcast and methods added to the end of
   the interface specification)
 
 v3.1.12.6
@@ -47,4 +79,3 @@ v3.1.9
 - Added subscription parameter to 'Event::onListenerRemoved' function. This is needed for managing the added and removed listeners respectively for mapping the listeners on the subscription.
 - Replaced variadic macros with variadic templates for CommonAPI logger.
 - Removed obsolete usleep() macro.
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ PROJECT(libcommonapi)
 # version of CommonAPI
 SET( LIBCOMMONAPI_MAJOR_VERSION 3 )
 SET( LIBCOMMONAPI_MINOR_VERSION 2 )
-SET( LIBCOMMONAPI_PATCH_VERSION 0 )
+SET( LIBCOMMONAPI_PATCH_VERSION 3 )
 
 message(STATUS "Project name: ${PROJECT_NAME}")
 
@@ -24,6 +24,10 @@ message(STATUS "This is CMake for Common API C++ Version ${COMPONENT_VERSION}.")
 set(DL_LIBRARY "")
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(DL_LIBRARY "dl")
+
+    # force all use of std::mutx and std::recursive_mutex to use runtime init
+    # instead of static initialization so mutexes can be hooked to enable PI as needed
+    add_definitions(-D_GTHREAD_USE_MUTEX_INIT_FUNC -D_GTHREAD_USE_RECURSIVE_MUTEX_INIT_FUNC)
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 ##############################################################################
@@ -102,7 +106,8 @@ IF(MSVC)
     add_definitions(-DCOMMONAPI_INTERNAL_COMPILATION -DCOMMONAPI_DLL_COMPILATION)
     add_compile_options(/EHsc /wd4996)
 ELSE ()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector -fasynchronous-unwind-tables -fno-omit-frame-pointer -Werror -DCOMMONAPI_INTERNAL_COMPILATION -fvisibility=hidden")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror=extra-semi -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector-strong -fasynchronous-unwind-tables -fno-omit-frame-pointer -Werror -DCOMMONAPI_INTERNAL_COMPILATION -fvisibility=hidden")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wformat-security -fstack-protector-strong")
 ENDIF(MSVC)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCOMMONAPI_LOGLEVEL=COMMONAPI_LOGLEVEL_${MAX_LOG_LEVEL}")
@@ -129,6 +134,9 @@ list(SORT CAPI_SRCS)
 add_library(CommonAPI SHARED ${CAPI_SRCS})
 target_link_libraries(CommonAPI PRIVATE ${DL_LIBRARY} ${DLT_LIBRARIES})
 set_target_properties(CommonAPI PROPERTIES VERSION ${LIBCOMMONAPI_MAJOR_VERSION}.${LIBCOMMONAPI_MINOR_VERSION}.${LIBCOMMONAPI_PATCH_VERSION} SOVERSION ${LIBCOMMONAPI_MAJOR_VERSION}.${LIBCOMMONAPI_MINOR_VERSION}.${LIBCOMMONAPI_PATCH_VERSION} LINKER_LANGUAGE C)
+target_include_directories(CommonAPI INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>)
 set_target_properties (CommonAPI PROPERTIES INTERFACE_LINK_LIBRARY "")
 
 ##############################################################################
@@ -167,23 +175,14 @@ export(PACKAGE CommonAPI)
 # Create the CommonAPIConfig.cmake and CommonAPIConfigVersion files ...
 file(RELATIVE_PATH REL_INCLUDE_DIR "${ABSOLUTE_INSTALL_CMAKE_DIR}" "${ABSOLUTE_INSTALL_INCLUDE_DIR}")
 
-# ... for the build tree
-set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include" )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CommonAPIConfig.cmake.in
   "${PROJECT_BINARY_DIR}/CommonAPIConfig.cmake" @ONLY)
-
-# ... for the install tree
-set(CONF_INCLUDE_DIRS "\${COMMONAPI_CMAKE_DIR}/${REL_INCLUDE_DIR}")
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CommonAPIConfig.cmake.in
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CommonAPIConfig.cmake" @ONLY)
-
-# ... for both
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CommonAPIConfigVersion.cmake.in
   "${PROJECT_BINARY_DIR}/CommonAPIConfigVersion.cmake" @ONLY)
 
 # Install the CommonAPIConfig.cmake and CommonAPIConfigVersion.cmake
 install(FILES
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CommonAPIConfig.cmake"
+  "${PROJECT_BINARY_DIR}/CommonAPIConfig.cmake"
   "${PROJECT_BINARY_DIR}/CommonAPIConfigVersion.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}")
 
@@ -255,4 +254,3 @@ if(NOT WIN32 AND PKG_CONFIG_FOUND)
 endif()
 
 ##############################################################################
-

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 ### CommonAPI C++ Core Runtime
 
 ##### Copyright
-Copyright (C) 2016-2020, Bayerische Motoren Werke Aktiengesellschaft (BMW AG).
+Copyright (C) 2016-2023, Bayerische Motoren Werke Aktiengesellschaft (BMW AG).
+Copyright (C) 2016-2023, COVESA
 
-This file is part of GENIVI Project IPC Common API C++.
-Contributions are licensed to the GENIVI Alliance under one or more Contribution License Agreements or MPL 2.0.
+This file is part of COVESA Project IPC Common API C++.
+Contributions are licensed to the COVESA under one or more Contribution License Agreements or MPL 2.0.
 
 ##### License
 This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
@@ -13,7 +14,7 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 The specification document and the user guide can be found in the CommonAPI documentation directory of the CommonAPI-Tools project as AsciiDoc document. A pdf version can be found at https://github.com/GENIVI/capicxx-core-tools/releases.
 
 ##### Further information
-https://genivi.github.io/capicxx-core-tools/
+https://covesa.github.io/capicxx-core-tools/
 
 ##### Build Instructions for Linux
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ##### Copyright
 Copyright (C) 2016-2020, Bayerische Motoren Werke Aktiengesellschaft (BMW AG).
-Copyright (C) 2016-2020, GENIVI Alliance, Inc.
 
 This file is part of GENIVI Project IPC Common API C++.
 Contributions are licensed to the GENIVI Alliance under one or more Contribution License Agreements or MPL 2.0.

--- a/cmake/CommonAPIConfig.cmake.in
+++ b/cmake/CommonAPIConfig.cmake.in
@@ -1,13 +1,17 @@
 # Config file for the CommonAPI package
-# It defines the following variables
-# COMMONAPI_INCLUDE_DIRS - include directories for CommonAPI
+# Exports the follwing targets:
+#   CommonAPI - CMake target for CommonAPI SomeIP
+# Additionally, the following variables are defined:
+#   COMMONAPI_VERSION - The CommonAPI version number
 
 # Compute paths
 get_filename_component(COMMONAPI_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(COMMONAPI_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
 include("${COMMONAPI_CMAKE_DIR}/CommonAPITargets.cmake")
+
+# Legacy variable, kept for compatibility
+get_target_property(COMMONAPI_INCLUDE_DIRS CommonAPI INTERFACE_INCLUDE_DIRECTORIES)
 
 set(COMMONAPI_VERSION @PACKAGE_VERSION@)
 set(COMMONAPI_VERSION_STRING "@PACKAGE_VERSION@")

--- a/include/CommonAPI/Address.hpp
+++ b/include/CommonAPI/Address.hpp
@@ -17,33 +17,33 @@
 
 namespace CommonAPI {
 
-class Address {
+class COMMONAPI_EXPORT_CLASS_EXPLICIT Address {
 public:
-    COMMONAPI_EXPORT Address();
-    COMMONAPI_EXPORT Address(const std::string &_address);
-    COMMONAPI_EXPORT Address(const std::string &_domain,
+    COMMONAPI_METHOD_EXPORT Address();
+    COMMONAPI_METHOD_EXPORT Address(const std::string &_address);
+    COMMONAPI_METHOD_EXPORT Address(const std::string &_domain,
             const std::string &_interface,
             const std::string &_instance);
-    COMMONAPI_EXPORT Address(const Address &_source);
-    COMMONAPI_EXPORT virtual ~Address() = default;
+    COMMONAPI_METHOD_EXPORT Address(const Address &_source);
+    COMMONAPI_METHOD_EXPORT virtual ~Address() = default;
 
-    COMMONAPI_EXPORT Address &operator=(const Address &_other);
+    COMMONAPI_METHOD_EXPORT Address &operator=(const Address &_other);
 
-    COMMONAPI_EXPORT bool operator==(const Address &_other) const;
-    COMMONAPI_EXPORT bool operator!=(const Address &_other) const;
-    COMMONAPI_EXPORT bool operator<(const Address &_other) const;
+    COMMONAPI_METHOD_EXPORT bool operator==(const Address &_other) const;
+    COMMONAPI_METHOD_EXPORT bool operator!=(const Address &_other) const;
+    COMMONAPI_METHOD_EXPORT bool operator<(const Address &_other) const;
 
-    COMMONAPI_EXPORT std::string getAddress() const;
-    COMMONAPI_EXPORT void setAddress(const std::string &_address);
+    COMMONAPI_METHOD_EXPORT std::string getAddress() const;
+    COMMONAPI_METHOD_EXPORT void setAddress(const std::string &_address);
 
-    COMMONAPI_EXPORT const std::string &getDomain() const;
-    COMMONAPI_EXPORT void setDomain(const std::string &_domain);
+    COMMONAPI_METHOD_EXPORT const std::string &getDomain() const;
+    COMMONAPI_METHOD_EXPORT void setDomain(const std::string &_domain);
 
-    COMMONAPI_EXPORT const std::string &getInterface() const;
-    COMMONAPI_EXPORT void setInterface(const std::string &_interface);
+    COMMONAPI_METHOD_EXPORT const std::string &getInterface() const;
+    COMMONAPI_METHOD_EXPORT void setInterface(const std::string &_interface);
 
-    COMMONAPI_EXPORT const std::string &getInstance() const;
-    COMMONAPI_EXPORT void setInstance(const std::string &_instance);
+    COMMONAPI_METHOD_EXPORT const std::string &getInstance() const;
+    COMMONAPI_METHOD_EXPORT void setInstance(const std::string &_instance);
 
 private:
     std::string domain_;

--- a/include/CommonAPI/Event.hpp
+++ b/include/CommonAPI/Event.hpp
@@ -39,7 +39,7 @@ public:
     /**
      * \brief Constructor
      */
-    Event() : nextSubscription_(0) {};
+    Event() : nextSubscription_(0) {}
 
     /**
      * \brief Subscribe a listener to this event
@@ -107,12 +107,13 @@ typename Event<Arguments_...>::Subscription Event<Arguments_...>::subscribe(List
     bool isFirstListener;
     Listeners listeners;
 
-    subscriptionMutex_.lock();
-    subscription = nextSubscription_++;
-    isFirstListener = (0 == pendingSubscriptions_.size()) && (pendingUnsubscriptions_.size() == subscriptions_.size());
-    listeners = std::make_tuple(listener, std::move(errorListener));
-    pendingSubscriptions_[subscription] = std::move(listeners);
-    subscriptionMutex_.unlock();
+    {
+        std::lock_guard<std::mutex> itsSubscriptionLock(subscriptionMutex_);
+        subscription = nextSubscription_++;
+        isFirstListener = (0 == pendingSubscriptions_.size()) && (pendingUnsubscriptions_.size() == subscriptions_.size());
+        listeners = std::make_tuple(listener, std::move(errorListener));
+        pendingSubscriptions_[subscription] = std::move(listeners);
+    }
 
     if (isFirstListener) {
         if (!pendingUnsubscriptions_.empty())
@@ -130,30 +131,31 @@ void Event<Arguments_...>::unsubscribe(const Subscription subscription) {
     bool hasUnsubscribed(false);
     Listener listener;
 
-    subscriptionMutex_.lock();
-    auto listenerIterator = subscriptions_.find(subscription);
-    if (subscriptions_.end() != listenerIterator) {
-        if (pendingUnsubscriptions_.end() == pendingUnsubscriptions_.find(subscription)) {
-            if (0 == pendingSubscriptions_.erase(subscription)) {
-                pendingUnsubscriptions_.insert(subscription);
-                listener = std::get<0>(listenerIterator->second);
-                hasUnsubscribed = true;
-            }
-            isLastListener = (pendingUnsubscriptions_.size() == subscriptions_.size());
-        }
-    }
-    else {
-        listenerIterator = pendingSubscriptions_.find(subscription);
-        if (pendingSubscriptions_.end() != listenerIterator) {
-            listener = std::get<0>(listenerIterator->second);
-            if (0 != pendingSubscriptions_.erase(subscription)) {
+    {
+        std::lock_guard<std::mutex> itsSubscriptionLock(subscriptionMutex_);
+        auto listenerIterator = subscriptions_.find(subscription);
+        if (subscriptions_.end() != listenerIterator) {
+            if (pendingUnsubscriptions_.end() == pendingUnsubscriptions_.find(subscription)) {
+                if (0 == pendingSubscriptions_.erase(subscription)) {
+                    pendingUnsubscriptions_.insert(subscription);
+                    listener = std::get<0>(listenerIterator->second);
+                    hasUnsubscribed = true;
+                }
                 isLastListener = (pendingUnsubscriptions_.size() == subscriptions_.size());
-                hasUnsubscribed = true;
             }
         }
+        else {
+            listenerIterator = pendingSubscriptions_.find(subscription);
+            if (pendingSubscriptions_.end() != listenerIterator) {
+                listener = std::get<0>(listenerIterator->second);
+                if (0 != pendingSubscriptions_.erase(subscription)) {
+                    isLastListener = (pendingUnsubscriptions_.size() == subscriptions_.size());
+                    hasUnsubscribed = true;
+                }
+            }
+        }
+        isLastListener = isLastListener && (0 == pendingSubscriptions_.size());
     }
-    isLastListener = isLastListener && (0 == pendingSubscriptions_.size());
-    subscriptionMutex_.unlock();
 
     if (hasUnsubscribed) {
         onListenerRemoved(listener, subscription);
@@ -166,8 +168,8 @@ void Event<Arguments_...>::unsubscribe(const Subscription subscription) {
 template<typename ... Arguments_>
 void Event<Arguments_...>::notifyListeners(const Arguments_&... eventArguments) {
 
-    notificationMutex_.lock();
-    subscriptionMutex_.lock();
+    std::lock_guard<std::mutex> itsNotificationLock(notificationMutex_);
+    std::unique_lock<std::mutex> itsSubscriptionLock(subscriptionMutex_);
     for (auto iterator = pendingUnsubscriptions_.begin();
          iterator != pendingUnsubscriptions_.end();
          iterator++) {
@@ -182,19 +184,17 @@ void Event<Arguments_...>::notifyListeners(const Arguments_&... eventArguments) 
     }
     pendingSubscriptions_.clear();
 
-    subscriptionMutex_.unlock();
+    itsSubscriptionLock.unlock();
     for (auto iterator = subscriptions_.begin(); iterator != subscriptions_.end(); iterator++) {
         (std::get<0>(iterator->second))(eventArguments...);
     }
-
-    notificationMutex_.unlock();
 }
 
 template<typename ... Arguments_>
 void Event<Arguments_...>::notifySpecificListener(const Subscription subscription, const Arguments_&... eventArguments) {
 
-    notificationMutex_.lock();
-    subscriptionMutex_.lock();
+    std::lock_guard<std::mutex> itsNotificationLock(notificationMutex_);
+    std::unique_lock<std::mutex> itsSubscriptionLock(subscriptionMutex_);
     for (auto iterator = pendingUnsubscriptions_.begin();
          iterator != pendingUnsubscriptions_.end();
          iterator++) {
@@ -210,50 +210,47 @@ void Event<Arguments_...>::notifySpecificListener(const Subscription subscriptio
     }
     pendingSubscriptions_.clear();
 
-
-    subscriptionMutex_.unlock();
+    itsSubscriptionLock.unlock();
     for (auto iterator = subscriptions_.begin(); iterator != subscriptions_.end(); iterator++) {
         if (subscription == iterator->first) {
             (std::get<0>(iterator->second))(eventArguments...);
         }
     }
-
-    notificationMutex_.unlock();
 }
 
 template<typename ... Arguments_>
 void Event<Arguments_...>::notifySpecificError(const Subscription subscription, const CallStatus status) {
 
-    notificationMutex_.lock();
-    subscriptionMutex_.lock();
-    for (auto iterator = pendingUnsubscriptions_.begin();
-         iterator != pendingUnsubscriptions_.end();
-         iterator++) {
-        subscriptions_.erase(*iterator);
-    }
-    pendingUnsubscriptions_.clear();
+    {
+        std::lock_guard<std::mutex> itsNotificationLock(notificationMutex_);
+        std::unique_lock<std::mutex> itsSubscriptionLock(subscriptionMutex_);
+        for (auto iterator = pendingUnsubscriptions_.begin();
+             iterator != pendingUnsubscriptions_.end();
+             iterator++) {
+            subscriptions_.erase(*iterator);
+        }
+        pendingUnsubscriptions_.clear();
 
-    for (auto iterator = pendingSubscriptions_.begin();
-         iterator != pendingSubscriptions_.end();
-         iterator++) {
-        subscriptions_.insert(*iterator);
-    }
-    pendingSubscriptions_.clear();
+        for (auto iterator = pendingSubscriptions_.begin();
+             iterator != pendingSubscriptions_.end();
+             iterator++) {
+            subscriptions_.insert(*iterator);
+        }
+        pendingSubscriptions_.clear();
 
-    subscriptionMutex_.unlock();
-    for (auto iterator = subscriptions_.begin(); iterator != subscriptions_.end(); iterator++) {
-        if (subscription == iterator->first) {
-            ErrorListener listener = std::get<1>(iterator->second);
-            if (listener) {
-                listener(status);
+        itsSubscriptionLock.unlock();
+        for (auto iterator = subscriptions_.begin(); iterator != subscriptions_.end(); iterator++) {
+            if (subscription == iterator->first) {
+                ErrorListener listener = std::get<1>(iterator->second);
+                if (listener) {
+                    listener(status);
+                }
             }
         }
     }
 
-    notificationMutex_.unlock();
-
     if (status != CommonAPI::CallStatus::SUCCESS) {
-        subscriptionMutex_.lock();
+        std::lock_guard<std::mutex> itsSubscriptionLock(subscriptionMutex_);
         auto listenerIterator = subscriptions_.find(subscription);
         if (subscriptions_.end() != listenerIterator) {
             if (pendingUnsubscriptions_.end() == pendingUnsubscriptions_.find(subscription)) {
@@ -268,15 +265,14 @@ void Event<Arguments_...>::notifySpecificError(const Subscription subscription, 
                 pendingSubscriptions_.erase(subscription);
             }
         }
-        subscriptionMutex_.unlock();
     }
 }
 
 template<typename ... Arguments_>
 void Event<Arguments_...>::notifyErrorListeners(const CallStatus status) {
 
-    notificationMutex_.lock();
-    subscriptionMutex_.lock();
+    std::lock_guard<std::mutex> itsNotificationLock(notificationMutex_);
+    std::unique_lock<std::mutex> itsSubscriptionLock(subscriptionMutex_);
     for (auto iterator = pendingUnsubscriptions_.begin();
          iterator != pendingUnsubscriptions_.end();
          iterator++) {
@@ -291,16 +287,13 @@ void Event<Arguments_...>::notifyErrorListeners(const CallStatus status) {
     }
     pendingSubscriptions_.clear();
 
-    subscriptionMutex_.unlock();
-
+    itsSubscriptionLock.unlock();
     for (auto iterator = subscriptions_.begin(); iterator != subscriptions_.end(); iterator++) {
         ErrorListener listener = std::get<1>(iterator->second);
         if (listener) {
             listener(status);
         }
     }
-
-    notificationMutex_.unlock();
 }
 
 

--- a/include/CommonAPI/Export.hpp
+++ b/include/CommonAPI/Export.hpp
@@ -10,6 +10,8 @@
     #define COMMONAPI_EXPORT __declspec(dllexport)
     #define COMMONAPI_EXPORT_CLASS_EXPLICIT
 
+    #define COMMONAPI_METHOD_EXPORT COMMONAPI_EXPORT
+
     #if COMMONAPI_DLL_COMPILATION
         #define COMMONAPI_IMPORT_EXPORT __declspec(dllexport)
     #else
@@ -19,6 +21,9 @@
     #define COMMONAPI_EXPORT __attribute__ ((visibility ("default")))
     #define COMMONAPI_EXPORT_CLASS_EXPLICIT COMMONAPI_EXPORT
     #define COMMONAPI_IMPORT_EXPORT
+
+    #define COMMONAPI_METHOD_EXPORT
+
 #endif
 
 #endif // COMMONAPI_EXPORT_HPP_

--- a/include/CommonAPI/Factory.hpp
+++ b/include/CommonAPI/Factory.hpp
@@ -28,7 +28,7 @@ public:
     typedef std::function<void(std::vector<std::string> &)> AvailableInstancesCbk_t;
     typedef std::function<void(bool)> InstanceAliveCbk_t;
 
-    virtual ~Factory() {};
+    virtual ~Factory() {}
 
     virtual void init() = 0;
 
@@ -54,8 +54,8 @@ public:
                               std::shared_ptr<StubBase> _stub,
                               std::shared_ptr<MainLoopContext> mainLoopContext) = 0;
 
-    virtual bool unregisterStub(const std::string &_domain, 
-                                const std::string &_interface, 
+    virtual bool unregisterStub(const std::string &_domain,
+                                const std::string &_interface,
                                 const std::string &_instance) = 0;
 };
 

--- a/include/CommonAPI/IniFileReader.hpp
+++ b/include/CommonAPI/IniFileReader.hpp
@@ -18,22 +18,22 @@
 
 namespace CommonAPI {
 
-class IniFileReader {
+class COMMONAPI_EXPORT_CLASS_EXPLICIT IniFileReader {
 public:
     class Section {
     public:
-        COMMONAPI_EXPORT const std::map<std::string, std::string> &getMappings() const;
-        COMMONAPI_EXPORT std::string getValue(const std::string &_key) const;
+        COMMONAPI_METHOD_EXPORT const std::map<std::string, std::string> &getMappings() const;
+        COMMONAPI_METHOD_EXPORT std::string getValue(const std::string &_key) const;
     private:
         std::map<std::string, std::string> mappings_;
 
     friend class IniFileReader;
     };
 
-    COMMONAPI_EXPORT bool load(const std::string &_path);
+    COMMONAPI_METHOD_EXPORT bool load(const std::string &_path);
 
-    COMMONAPI_EXPORT const std::map<std::string, std::shared_ptr<Section>> &getSections() const;
-    COMMONAPI_EXPORT std::shared_ptr<Section> getSection(const std::string &_name) const;
+    COMMONAPI_METHOD_EXPORT const std::map<std::string, std::shared_ptr<Section>> &getSections() const;
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<Section> getSection(const std::string &_name) const;
 
 private:
     std::map<std::string, std::shared_ptr<Section>> sections_;

--- a/include/CommonAPI/Logger.hpp
+++ b/include/CommonAPI/Logger.hpp
@@ -26,9 +26,9 @@
 namespace CommonAPI {
 
 
-class Logger {
+class COMMONAPI_EXPORT_CLASS_EXPLICIT Logger {
 public:
-    enum class Level : std::uint8_t COMMONAPI_EXPORT {
+    enum class Level : std::uint8_t COMMONAPI_METHOD_EXPORT {
         CAPI_LOG_NONE = 0,
         CAPI_LOG_FATAL = 1,
         CAPI_LOG_ERROR = 2,
@@ -41,37 +41,37 @@ public:
     ~Logger();
 
     template<typename... LogEntries_>
-    COMMONAPI_EXPORT static void fatal(LogEntries_&&... _entries) {
+    COMMONAPI_METHOD_EXPORT static void fatal(LogEntries_&&... _entries) {
         log(Logger::Level::CAPI_LOG_FATAL, std::forward<LogEntries_>(_entries)...);
     }
 
     template<typename... LogEntries_>
-    COMMONAPI_EXPORT static void error(LogEntries_&&... _entries) {
+    COMMONAPI_METHOD_EXPORT static void error(LogEntries_&&... _entries) {
         log(Logger::Level::CAPI_LOG_ERROR, std::forward<LogEntries_>(_entries)...);
     }
 
     template<typename... LogEntries_>
-    COMMONAPI_EXPORT static void warning(LogEntries_&&... _entries) {
+    COMMONAPI_METHOD_EXPORT static void warning(LogEntries_&&... _entries) {
         log(Logger::Level::CAPI_LOG_WARNING, std::forward<LogEntries_>(_entries)...);
     }
 
     template<typename... LogEntries_>
-    COMMONAPI_EXPORT static void info(LogEntries_&&... _entries) {
+    COMMONAPI_METHOD_EXPORT static void info(LogEntries_&&... _entries) {
         log(Logger::Level::CAPI_LOG_INFO, std::forward<LogEntries_>(_entries)...);
     }
 
     template<typename... LogEntries_>
-    COMMONAPI_EXPORT static void debug(LogEntries_&&... _entries) {
+    COMMONAPI_METHOD_EXPORT static void debug(LogEntries_&&... _entries) {
         log(Logger::Level::CAPI_LOG_DEBUG, std::forward<LogEntries_>(_entries)...);
     }
 
     template<typename... LogEntries_>
-    COMMONAPI_EXPORT static void verbose(LogEntries_&&... _entries) {
+    COMMONAPI_METHOD_EXPORT static void verbose(LogEntries_&&... _entries) {
         log(Logger::Level::CAPI_LOG_VERBOSE, std::forward<LogEntries_>(_entries)...);
     }
 
     template<typename... LogEntries_>
-    COMMONAPI_EXPORT static void log(Logger::Level _level, LogEntries_&&... _entries) {
+    COMMONAPI_METHOD_EXPORT static void log(Logger::Level _level, LogEntries_&&... _entries) {
         if (isLogged(_level)) {
             std::stringstream buffer;
             logIntern(buffer, std::forward<LogEntries_>(_entries)...);
@@ -79,22 +79,22 @@ public:
         }
     }
 
-    static void init(bool _useConsole, const std::string &_fileName,
+    COMMONAPI_METHOD_EXPORT static void init(bool _useConsole, const std::string &_fileName,
                      bool _useDlt, const std::string& _level);
 
 private:
     class LoggerImpl;
-    static std::unique_ptr<LoggerImpl> loggerImpl_;
+    COMMONAPI_METHOD_EXPORT static std::shared_ptr<LoggerImpl> getLoggerImpl();
 
-    COMMONAPI_EXPORT static bool isLogged(Level _level);
-    COMMONAPI_EXPORT static void doLog(Level _level, const std::string& _message);
+    COMMONAPI_METHOD_EXPORT static bool isLogged(Level _level);
+    COMMONAPI_METHOD_EXPORT static void doLog(Level _level, const std::string& _message);
 
-    COMMONAPI_EXPORT static void logIntern(std::stringstream &_buffer) {
+    COMMONAPI_METHOD_EXPORT static void logIntern(std::stringstream &_buffer) {
         (void)_buffer;
     }
 
     template<typename LogEntry_, typename... MoreLogEntries_>
-    COMMONAPI_EXPORT static void logIntern(std::stringstream &_buffer, LogEntry_&& _entry,
+    COMMONAPI_METHOD_EXPORT static void logIntern(std::stringstream &_buffer, LogEntry_&& _entry,
                            MoreLogEntries_&& ... _moreEntries) {
         _buffer << _entry;
         logIntern(_buffer, std::forward<MoreLogEntries_>(_moreEntries)...);

--- a/include/CommonAPI/MainLoopContext.hpp
+++ b/include/CommonAPI/MainLoopContext.hpp
@@ -198,93 +198,93 @@ typedef WakeupListenerList::iterator WakeupListenerSubscription;
  * Watches, Timeouts and Wakeup-Events that need to be handled by your Main Loop implementation.
  *
  */
-class MainLoopContext {
+class COMMONAPI_EXPORT_CLASS_EXPLICIT MainLoopContext {
 public:
-    COMMONAPI_EXPORT MainLoopContext(const std::string &_name = "COMMONAPI_DEFAULT_MAINLOOP_CONTEXT")
+    COMMONAPI_METHOD_EXPORT MainLoopContext(const std::string &_name = "COMMONAPI_DEFAULT_MAINLOOP_CONTEXT")
         : name_(_name){
     }
 
-    COMMONAPI_EXPORT MainLoopContext(const MainLoopContext&) = delete;
-    COMMONAPI_EXPORT MainLoopContext& operator=(const MainLoopContext&) = delete;
-    COMMONAPI_EXPORT MainLoopContext(MainLoopContext&&) = delete;
-    COMMONAPI_EXPORT MainLoopContext& operator=(MainLoopContext&&) = delete;
+    COMMONAPI_METHOD_EXPORT MainLoopContext(const MainLoopContext&) = delete;
+    COMMONAPI_METHOD_EXPORT MainLoopContext& operator=(const MainLoopContext&) = delete;
+    COMMONAPI_METHOD_EXPORT MainLoopContext(MainLoopContext&&) = delete;
+    COMMONAPI_METHOD_EXPORT MainLoopContext& operator=(MainLoopContext&&) = delete;
 
-    COMMONAPI_EXPORT const std::string &getName() const;
+    COMMONAPI_METHOD_EXPORT const std::string &getName() const;
 
     /**
      * \brief Registers for all DispatchSources that are added or removed.
      */
-    COMMONAPI_EXPORT DispatchSourceListenerSubscription subscribeForDispatchSources(DispatchSourceAddedCallback dispatchAddedCallback, DispatchSourceRemovedCallback dispatchRemovedCallback);
+    COMMONAPI_METHOD_EXPORT DispatchSourceListenerSubscription subscribeForDispatchSources(DispatchSourceAddedCallback dispatchAddedCallback, DispatchSourceRemovedCallback dispatchRemovedCallback);
 
     /**
      * \brief Registers for all Watches that are added or removed.
      */
-    COMMONAPI_EXPORT WatchListenerSubscription subscribeForWatches(WatchAddedCallback watchAddedCallback, WatchRemovedCallback watchRemovedCallback);
+    COMMONAPI_METHOD_EXPORT WatchListenerSubscription subscribeForWatches(WatchAddedCallback watchAddedCallback, WatchRemovedCallback watchRemovedCallback);
 
     /**
      * \brief Registers for all Timeouts that are added or removed.
      */
-    COMMONAPI_EXPORT TimeoutSourceListenerSubscription subscribeForTimeouts(TimeoutSourceAddedCallback timeoutAddedCallback, TimeoutSourceRemovedCallback timeoutRemovedCallback);
+    COMMONAPI_METHOD_EXPORT TimeoutSourceListenerSubscription subscribeForTimeouts(TimeoutSourceAddedCallback timeoutAddedCallback, TimeoutSourceRemovedCallback timeoutRemovedCallback);
 
     /**
      * \brief Registers for all Wakeup-Events that need to interrupt a call to "poll".
      */
-    COMMONAPI_EXPORT WakeupListenerSubscription subscribeForWakeupEvents(WakeupCallback wakeupCallback);
+    COMMONAPI_METHOD_EXPORT WakeupListenerSubscription subscribeForWakeupEvents(WakeupCallback wakeupCallback);
 
     /**
      * \brief Unsubscribes your listeners for DispatchSources.
      */
-    COMMONAPI_EXPORT void unsubscribeForDispatchSources(DispatchSourceListenerSubscription subscription);
+    COMMONAPI_METHOD_EXPORT void unsubscribeForDispatchSources(DispatchSourceListenerSubscription subscription);
 
     /**
      * \brief Unsubscribes your listeners for Watches.
      */
-    COMMONAPI_EXPORT void unsubscribeForWatches(WatchListenerSubscription subscription);
+    COMMONAPI_METHOD_EXPORT void unsubscribeForWatches(WatchListenerSubscription subscription);
 
     /**
      * \brief Unsubscribes your listeners for Timeouts.
      */
-    COMMONAPI_EXPORT void unsubscribeForTimeouts(TimeoutSourceListenerSubscription subscription);
+    COMMONAPI_METHOD_EXPORT void unsubscribeForTimeouts(TimeoutSourceListenerSubscription subscription);
 
     /**
      * \brief Unsubscribes your listeners for Wakeup-Events.
      */
-    COMMONAPI_EXPORT void unsubscribeForWakeupEvents(WakeupListenerSubscription subscription);
+    COMMONAPI_METHOD_EXPORT void unsubscribeForWakeupEvents(WakeupListenerSubscription subscription);
 
     /**
      * \brief Notifies all listeners about a new DispatchSource.
      */
-    COMMONAPI_EXPORT void registerDispatchSource(DispatchSource* dispatchSource, const DispatchPriority dispatchPriority = DispatchPriority::DEFAULT);
+    COMMONAPI_METHOD_EXPORT void registerDispatchSource(DispatchSource* dispatchSource, const DispatchPriority dispatchPriority = DispatchPriority::DEFAULT);
 
     /**
      * \brief Notifies all listeners about the removal of a DispatchSource.
      */
-    COMMONAPI_EXPORT void deregisterDispatchSource(DispatchSource* dispatchSource);
+    COMMONAPI_METHOD_EXPORT void deregisterDispatchSource(DispatchSource* dispatchSource);
 
     /**
      * \brief Notifies all listeners about a new Watch.
      */
-    COMMONAPI_EXPORT void registerWatch(Watch* watch, const DispatchPriority dispatchPriority = DispatchPriority::DEFAULT);
+    COMMONAPI_METHOD_EXPORT void registerWatch(Watch* watch, const DispatchPriority dispatchPriority = DispatchPriority::DEFAULT);
 
     /**
      * \brief Notifies all listeners about the removal of a Watch.
      */
-    COMMONAPI_EXPORT void deregisterWatch(Watch* watch);
+    COMMONAPI_METHOD_EXPORT void deregisterWatch(Watch* watch);
 
     /**
      * \brief Notifies all listeners about a new Timeout.
      */
-    COMMONAPI_EXPORT void registerTimeoutSource(Timeout* timeoutEvent, const DispatchPriority dispatchPriority = DispatchPriority::DEFAULT);
+    COMMONAPI_METHOD_EXPORT void registerTimeoutSource(Timeout* timeoutEvent, const DispatchPriority dispatchPriority = DispatchPriority::DEFAULT);
 
     /**
      * \brief Notifies all listeners about the removal of a Timeout.
      */
-    COMMONAPI_EXPORT void deregisterTimeoutSource(Timeout* timeoutEvent);
+    COMMONAPI_METHOD_EXPORT void deregisterTimeoutSource(Timeout* timeoutEvent);
 
     /**
      * \brief Notifies all listeners about a wakeup event that just happened.
      */
-    COMMONAPI_EXPORT void wakeup();
+    COMMONAPI_METHOD_EXPORT void wakeup();
 
     /**
      * \brief Will return true if at least one subscribe for DispatchSources or Watches has been called.
@@ -292,7 +292,7 @@ public:
      * This function will be used to prevent creation of a factory if a mainloop context is given, but
      * no listeners have been registered. This is done in order to ensure correct use of the mainloop context.
      */
-    COMMONAPI_EXPORT bool isInitialized();
+    COMMONAPI_METHOD_EXPORT bool isInitialized();
 
  private:
     DispatchSourceListenerList dispatchSourceListeners_;

--- a/include/CommonAPI/Proxy.hpp
+++ b/include/CommonAPI/Proxy.hpp
@@ -49,4 +49,3 @@ protected:
 } // namespace CommonAPI
 
 #endif // COMMONAPI_PROXY_HPP_
-

--- a/include/CommonAPI/ProxyManager.hpp
+++ b/include/CommonAPI/ProxyManager.hpp
@@ -22,7 +22,7 @@
 
 namespace CommonAPI {
 
-class ProxyManager {
+class COMMONAPI_EXPORT_CLASS_EXPLICIT ProxyManager {
 public:
     typedef std::function<void(const CallStatus &, const std::vector<std::string> &)> GetAvailableInstancesCallback;
     typedef std::function<void(const CallStatus &, const AvailabilityStatus &)> GetInstanceAvailabilityStatusCallback;
@@ -72,12 +72,12 @@ public:
     }
 
 protected:
-    COMMONAPI_EXPORT std::shared_ptr<Proxy> createProxy(const std::string &,
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<Proxy> createProxy(const std::string &,
                                        const std::string &,
                                        const std::string &,
                                        const ConnectionId_t &_connection) const;
 
-    COMMONAPI_EXPORT std::shared_ptr<Proxy> createProxy(const std::string &,
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<Proxy> createProxy(const std::string &,
                                        const std::string &,
                                        const std::string &,
                                        std::shared_ptr<MainLoopContext> _context) const;

--- a/include/CommonAPI/Runtime.hpp
+++ b/include/CommonAPI/Runtime.hpp
@@ -29,18 +29,18 @@ class Proxy;
 class ProxyManager;
 class StubBase;
 
-class Runtime {
+class COMMONAPI_EXPORT_CLASS_EXPLICIT Runtime {
 public:
-    COMMONAPI_EXPORT static std::string getProperty(const std::string &_name);
-    COMMONAPI_EXPORT static void setProperty(const std::string &_name, const std::string &_value);
+    COMMONAPI_METHOD_EXPORT static std::string getProperty(const std::string &_name);
+    COMMONAPI_METHOD_EXPORT static void setProperty(const std::string &_name, const std::string &_value);
 
-    COMMONAPI_EXPORT static std::shared_ptr<Runtime> get();
+    COMMONAPI_METHOD_EXPORT static std::shared_ptr<Runtime> get();
 
-    COMMONAPI_EXPORT Runtime();
-    COMMONAPI_EXPORT virtual ~Runtime();
+    COMMONAPI_METHOD_EXPORT Runtime();
+    COMMONAPI_METHOD_EXPORT virtual ~Runtime();
 
     template<template<typename ...> class ProxyClass_, typename ... AttributeExtensions_>
-    COMMONAPI_EXPORT std::shared_ptr<
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<
         ProxyClass_<AttributeExtensions_...>
     >
     buildProxy(const std::string &_domain,
@@ -59,7 +59,7 @@ public:
     }
 
     template<template<typename ...> class ProxyClass_, typename ... AttributeExtensions_>
-    COMMONAPI_EXPORT std::shared_ptr<
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<
         ProxyClass_<AttributeExtensions_...>
     >
     buildProxy(const std::string &_domain,
@@ -77,7 +77,7 @@ public:
     }
 
     template <template<typename ...> class ProxyClass_, template<typename> class AttributeExtension_>
-    COMMONAPI_EXPORT std::shared_ptr<typename DefaultAttributeProxyHelper<ProxyClass_, AttributeExtension_>::class_t>
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<typename DefaultAttributeProxyHelper<ProxyClass_, AttributeExtension_>::class_t>
     buildProxyWithDefaultAttributeExtension(const std::string &_domain,
                                             const std::string &_instance,
                                             const ConnectionId_t &_connectionId = DEFAULT_CONNECTION_ID) {
@@ -93,7 +93,7 @@ public:
     }
 
     template <template<typename ...> class ProxyClass_, template<typename> class AttributeExtension_>
-    COMMONAPI_EXPORT std::shared_ptr<typename DefaultAttributeProxyHelper<ProxyClass_, AttributeExtension_>::class_t>
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<typename DefaultAttributeProxyHelper<ProxyClass_, AttributeExtension_>::class_t>
     buildProxyWithDefaultAttributeExtension(const std::string &_domain,
                                             const std::string &_instance,
                                             std::shared_ptr<MainLoopContext> _context) {
@@ -109,7 +109,7 @@ public:
     }
 
     template<typename Stub_>
-    COMMONAPI_EXPORT bool registerService(const std::string &_domain,
+    COMMONAPI_METHOD_EXPORT bool registerService(const std::string &_domain,
                          const std::string &_instance,
                          std::shared_ptr<Stub_> _service,
                          const ConnectionId_t &_connectionId = DEFAULT_CONNECTION_ID) {
@@ -117,56 +117,56 @@ public:
     }
 
     template<typename Stub_>
-    COMMONAPI_EXPORT bool registerService(const std::string &_domain,
+    COMMONAPI_METHOD_EXPORT bool registerService(const std::string &_domain,
                          const std::string &_instance,
                          std::shared_ptr<Stub_> _service,
                          std::shared_ptr<MainLoopContext> _context) {
         return registerStub(_domain, Stub_::StubInterface::getInterface(), _instance, _service, _context);
     }
 
-    COMMONAPI_EXPORT bool unregisterService(const std::string &_domain,
+    COMMONAPI_METHOD_EXPORT bool unregisterService(const std::string &_domain,
                             const std::string &_interface,
                             const std::string &_instance) {
         return unregisterStub(_domain, _interface, _instance);
     }
 
-    COMMONAPI_EXPORT bool registerFactory(const std::string &_ipc, std::shared_ptr<Factory> _factory);
-    COMMONAPI_EXPORT bool unregisterFactory(const std::string &_ipc);
+    COMMONAPI_METHOD_EXPORT bool registerFactory(const std::string &_ipc, std::shared_ptr<Factory> _factory);
+    COMMONAPI_METHOD_EXPORT bool unregisterFactory(const std::string &_ipc);
 
-    inline const std::string &getDefaultBinding() const { return defaultBinding_; };
+    inline const std::string &getDefaultBinding() const { return defaultBinding_; }
 
-    COMMONAPI_EXPORT void initFactories();
-    COMMONAPI_EXPORT Timeout_t getDefaultCallTimeout() const;
+    COMMONAPI_METHOD_EXPORT void initFactories();
+    COMMONAPI_METHOD_EXPORT Timeout_t getDefaultCallTimeout() const;
 
 private:
-    COMMONAPI_EXPORT void init();
-    COMMONAPI_EXPORT bool readConfiguration();
-    COMMONAPI_EXPORT bool splitAddress(const std::string &, std::string &, std::string &, std::string &);
+    COMMONAPI_METHOD_EXPORT void init();
+    COMMONAPI_METHOD_EXPORT bool readConfiguration();
+    COMMONAPI_METHOD_EXPORT bool splitAddress(const std::string &, std::string &, std::string &, std::string &);
 
-    COMMONAPI_EXPORT std::shared_ptr<Proxy> createProxy(const std::string &, const std::string &, const std::string &,
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<Proxy> createProxy(const std::string &, const std::string &, const std::string &,
                                        const ConnectionId_t &);
-    COMMONAPI_EXPORT std::shared_ptr<Proxy> createProxy(const std::string &, const std::string &, const std::string &,
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<Proxy> createProxy(const std::string &, const std::string &, const std::string &,
                                        std::shared_ptr<MainLoopContext>);
 
-    COMMONAPI_EXPORT std::shared_ptr<Proxy> createProxyHelper(const std::string &, const std::string &, const std::string &,
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<Proxy> createProxyHelper(const std::string &, const std::string &, const std::string &,
                                              const ConnectionId_t &, bool);
-    COMMONAPI_EXPORT std::shared_ptr<Proxy> createProxyHelper(const std::string &, const std::string &, const std::string &,
+    COMMONAPI_METHOD_EXPORT std::shared_ptr<Proxy> createProxyHelper(const std::string &, const std::string &, const std::string &,
                                              std::shared_ptr<MainLoopContext>, bool);
 
 
-    COMMONAPI_EXPORT bool registerStub(const std::string &, const std::string &, const std::string &,
+    COMMONAPI_METHOD_EXPORT bool registerStub(const std::string &, const std::string &, const std::string &,
                       std::shared_ptr<StubBase>, const ConnectionId_t &);
-    COMMONAPI_EXPORT bool registerStub(const std::string &, const std::string &, const std::string &,
+    COMMONAPI_METHOD_EXPORT bool registerStub(const std::string &, const std::string &, const std::string &,
                       std::shared_ptr<StubBase>, std::shared_ptr<MainLoopContext>);
-    COMMONAPI_EXPORT bool registerStubHelper(const std::string &, const std::string &, const std::string &,
+    COMMONAPI_METHOD_EXPORT bool registerStubHelper(const std::string &, const std::string &, const std::string &,
                             std::shared_ptr<StubBase>, const ConnectionId_t &, bool);
-    COMMONAPI_EXPORT bool registerStubHelper(const std::string &, const std::string &, const std::string &,
+    COMMONAPI_METHOD_EXPORT bool registerStubHelper(const std::string &, const std::string &, const std::string &,
                             std::shared_ptr<StubBase>, std::shared_ptr<MainLoopContext>, bool);
 
-    COMMONAPI_EXPORT bool unregisterStub(const std::string &, const std::string &, const std::string &);
+    COMMONAPI_METHOD_EXPORT bool unregisterStub(const std::string &, const std::string &, const std::string &);
 
-    COMMONAPI_EXPORT std::string getLibrary(const std::string &, const std::string &, const std::string &, bool);
-    COMMONAPI_EXPORT bool loadLibrary(const std::string &);
+    COMMONAPI_METHOD_EXPORT std::string getLibrary(const std::string &, const std::string &, const std::string &, bool);
+    COMMONAPI_METHOD_EXPORT bool loadLibrary(const std::string &);
 
 private:
     std::string usedConfig_;

--- a/include/CommonAPI/Struct.hpp
+++ b/include/CommonAPI/Struct.hpp
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include <tuple>
+#include <CommonAPI/Logger.hpp>
 
 namespace CommonAPI {
 
@@ -38,8 +39,12 @@ struct StructReader<Index_, Input_, V_<Values_...>, D_<Depls_...>> {
                     V_<Values_...> &_values,
                     const D_<Depls_...> *_depls) {
         StructReader<Index_-1, Input_, V_<Values_...>, D_<Depls_...>>{}(_input, _values, _depls);
-        _input.template readValue<>(std::get<Index_>(_values.values_),
-                                    (_depls ? std::get<Index_>(_depls->values_) : nullptr));
+        if (_input.hasError()) {
+            COMMONAPI_ERROR("StructReader: deserialization failed at index: ", Index_-1);
+        } else {
+            _input.template readValue<>(std::get<Index_>(_values.values_),
+                                        (_depls ? std::get<Index_>(_depls->values_) : nullptr));
+        }
     }
 };
 
@@ -52,7 +57,11 @@ struct StructReader<Index_, Input_, V_<Values_...>, D_> {
                     V_<Values_...> &_values,
                     const D_ *_depls) {
         StructReader<Index_-1, Input_, V_<Values_...>, D_>{}(_input, _values, _depls);
-        _input.template readValue<D_>(std::get<Index_>(_values.values_));
+        if (_input.hasError()) {
+            COMMONAPI_ERROR("StructReader: deserialization failed at index: ", Index_-1);
+        } else {
+            _input.template readValue<D_>(std::get<Index_>(_values.values_));
+        }
     }
 };
 
@@ -65,6 +74,9 @@ struct StructReader<0, Input_, V_<Values_...>, D_<Depls_...>> {
                     const D_<Depls_...> *_depls) {
         _input.template readValue<>(std::get<0>(_values.values_),
                                     (_depls ? std::get<0>(_depls->values_) : nullptr));
+        if (_input.hasError()) {
+            COMMONAPI_ERROR("StructReader: deserialization failed at index: 0");
+        }
     }
 };
 
@@ -77,6 +89,9 @@ struct StructReader<0, Input_, V_<Values_...>, D_> {
                     const D_ *_depls) {
         (void)_depls;
         _input.template readValue<D_>(std::get<0>(_values.values_));
+        if (_input.hasError()) {
+            COMMONAPI_ERROR("StructReader: deserialization failed at index: 0");
+        }
     }
 };
 

--- a/include/CommonAPI/Types.hpp
+++ b/include/CommonAPI/Types.hpp
@@ -96,6 +96,7 @@ typedef std::uint32_t gid_t;
 typedef ::uid_t uid_t;
 typedef ::gid_t gid_t;
 #endif
+
 /**
  * \brief Identifies a client sending a call to a stub.
  *
@@ -109,6 +110,12 @@ public:
     virtual std::size_t hashCode() = 0;
     virtual uid_t getUid() const = 0;
     virtual gid_t getGid() const = 0;
+    virtual std::string getEnv() const {
+        return "";
+    }
+    virtual std::string getHostAddress() const {
+        return "";
+    }
 };
 
 template <typename ... Args_>

--- a/include/CommonAPI/Variant.hpp
+++ b/include/CommonAPI/Variant.hpp
@@ -650,19 +650,23 @@ Variant<Types_...>::~Variant() {
 
 template<typename... Types_>
 Variant<Types_...>& Variant<Types_...>::operator=(const Variant<Types_...> &_source) {
-    AssignmentVisitor<Types_...> visitor(*this, hasValue());
-    ApplyVoidVisitor<
-        AssignmentVisitor<Types_...>, Variant<Types_...>, Types_...
-    >::visit(visitor, _source);
+    if (*this != _source) {
+        AssignmentVisitor<Types_...> visitor(*this, hasValue());
+        ApplyVoidVisitor<
+            AssignmentVisitor<Types_...>, Variant<Types_...>, Types_...
+        >::visit(visitor, _source);
+    }
     return *this;
 }
 
 template<typename... Types_>
 Variant<Types_...>& Variant<Types_...>::operator=(Variant<Types_...> &&_source) {
-    AssignmentVisitor<Types_...> visitor(*this, hasValue());
-    ApplyVoidVisitor<
-        AssignmentVisitor<Types_...>, Variant<Types_...>, Types_...
-    >::visit(visitor, _source);
+    if (*this != _source) {
+        AssignmentVisitor<Types_...> visitor(*this, hasValue());
+        ApplyVoidVisitor<
+            AssignmentVisitor<Types_...>, Variant<Types_...>, Types_...
+        >::visit(visitor, _source);
+    }
     return *this;
 }
 

--- a/libcommonapi.yaml
+++ b/libcommonapi.yaml
@@ -1,0 +1,6 @@
+- name: libcommonapi
+ version: 3.2.3
+ vendor: Lynx Team
+ license:
+  concluded: CLOSED and MPLv2
+  declared: MPLv2

--- a/src/CommonAPI/CallInfo.cpp
+++ b/src/CommonAPI/CallInfo.cpp
@@ -35,6 +35,11 @@ CallInfo::CallInfo(Timeout_t _timeout, Sender_t _sender)
             timeout_ = globalCallTimeout;
         }
     }
+
+    //If timeout is set to -1, timeout should be the max value possible
+    if(timeout_ < 0){
+        timeout_ = std::numeric_limits<Timeout_t>::max();
+    }
 }
 
 } // namespace CommonAPI

--- a/src/CommonAPI/Utils.cpp
+++ b/src/CommonAPI/Utils.cpp
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include <cctype>
 #include <algorithm>
 #include <sstream>
 #include <functional>
@@ -31,7 +32,7 @@ void trim(std::string& toTrim) {
         std::find_if(
             toTrim.begin(),
             toTrim.end(),
-            std::not1(std::ptr_fun(isspace))
+            [](int c) {return !std::isspace(c);}
         )
     );
 
@@ -39,7 +40,7 @@ void trim(std::string& toTrim) {
         std::find_if(
             toTrim.rbegin(),
             toTrim.rend(),
-            std::not1(std::ptr_fun(isspace))).base(),
+            [](int c) {return !std::isspace(c);}).base(),
             toTrim.end()
     );
 }


### PR DESCRIPTION
 - Fixed warnings with gcc11 for Wextra-extra-semi flag
 - Fix capi-core-runtime Runtime::loadLibrary
 - vSomeIP Security: Update vsomeip_sec
 - Fixed commonapi-core-runtime windows build
 - Fix race condition.
 - Remove mutex and add exception handling to RuntimeDeinit.
 - Fix double initialization of loggerImpl.
 - Linux: avoid static initialization of std::mutex
 - Replace deprecated std::ptr_fun
 - Properly initialize Runtime::defaultCallTimeout_
 - Removed GENIVI copyright line
 - Fix bug in assignment operator of Variant in case of self-assignment
 - Ensure to stop struct deserialization on error
 - Implement "no_timeout" in method responses
 - Use COMMONAPI_EXPORT_CLASS_EXPLICIT to export classes
 - Removed libdlt dependency from android
 - Add support to logs in Android
 - Update android build files
 - Support retrieval of environment (hostname) from client identifier.
 - Use lock objects and remove self assignment.