### PR TITLE
Including missing <string> include

### DIFF
--- a/include/CommonAPI/Types.hpp
+++ b/include/CommonAPI/Types.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <unordered_set>
 #include <memory>
+#include <string>
 #include <tuple>
 
 #ifndef _WIN32


### PR DESCRIPTION
This appears to be required with g++14.

Without it I get:
```
[ 72%] Building CXX object CMakeFiles/CommonAPI.dir/src/CommonAPI/ProxyManager.cpp.o                                                                                                                                                                                                                                          
In file included from /home/matt/workspace/capicxx-import-tools/conan/capicxx-core-runtime/src/include/CommonAPI/Config.hpp:13,                                                                                                                                                                                               
                 from /home/matt/workspace/capicxx-import-tools/conan/capicxx-core-runtime/src/include/CommonAPI/CallInfo.hpp:13,                                                                                                                                                                                             
                 from /home/matt/workspace/capicxx-import-tools/conan/capicxx-core-runtime/src/src/CommonAPI/CallInfo.cpp:6:                                                                                                                                                                                                  
/home/matt/workspace/capicxx-import-tools/conan/capicxx-core-runtime/src/include/CommonAPI/Types.hpp:113:40: error: return type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’} is incomplete                                                                                                                    
  113 |     virtual std::string getEnv() const {                                                                                                                                                                                                                                                                              
      |                                        ^                                                                                                                                                                                                                                                                              
/home/matt/workspace/capicxx-import-tools/conan/capicxx-core-runtime/src/include/CommonAPI/Types.hpp:116:48: error: return type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’} is incomplete                                                                                                                    
  116 |     virtual std::string getHostAddress() const {
```

This is with:
```
-- The C compiler identification is GNU 14.1.1                                                                                                                                                                                                                                                                              
-- The CXX compiler identification is GNU 14.1.1
```